### PR TITLE
feat(reward): using max cutted reward

### DIFF
--- a/configs/exp/normal.yaml
+++ b/configs/exp/normal.yaml
@@ -3,7 +3,6 @@ group: Reproduce Normal
 
 env:
   path: ./instances/eternity_A.txt
-  reward: win
   max_steps: 64
 
 model:
@@ -27,7 +26,6 @@ reinforce:
   advantage: no-advantage
   entropy_weight: 1.0e-5
   total_rollouts: 10_000
-  gamma: 1.00
   clip_value: 5.0
 
 rollout_buffer:

--- a/configs/exp/normal.yaml
+++ b/configs/exp/normal.yaml
@@ -31,7 +31,7 @@ reinforce:
   clip_value: 5.0
 
 rollout_buffer:
-  buffer_size: 81_920  # Number of played games in a single buffer.
+  buffer_size: 163_840  # Number of played games in a single buffer.
   batches_per_rollouts: 200  # Number of times we sample from the buffer.
   batch_size: 40_960  # Number of samples in a single batch.
 

--- a/configs/exp/trivial.yaml
+++ b/configs/exp/trivial.yaml
@@ -3,7 +3,6 @@ group: Trivial A
 
 env:
   path: ./instances/eternity_trivial_A.txt
-  reward: win
   max_steps: 8
 
 model:
@@ -27,7 +26,6 @@ reinforce:
   advantage: no-advantage
   entropy_weight: 1.0e-5
   total_rollouts: 200
-  gamma: 1.00
   clip_value: 5.0
 
 rollout_buffer:

--- a/configs/exp/trivial_B.yaml
+++ b/configs/exp/trivial_B.yaml
@@ -3,7 +3,6 @@ group: Trivial B
 
 env:
   path: ./instances/eternity_trivial_B.txt
-  reward: win
   max_steps: 24
 
 model:
@@ -27,7 +26,6 @@ reinforce:
   advantage: no-advantage
   entropy_weight: 1.0e-5
   total_rollouts: 5000
-  gamma: 1.00
   clip_value: 0.05
 
 rollout_buffer:

--- a/main.py
+++ b/main.py
@@ -97,7 +97,7 @@ def init_scheduler(
 def init_trainer(
     config: DictConfig,
     env: EternityEnv,
-    model: nn.Module,
+    model: CNNPolicy | DDP,
     optimizer: optim.Optimizer,
     scheduler: optim.lr_scheduler.LinearLR,
 ) -> Reinforce:

--- a/main.py
+++ b/main.py
@@ -36,7 +36,6 @@ def init_env(config: DictConfig) -> EternityEnv:
     env = EternityEnv.from_file(
         config.exp.env.path,
         config.exp.rollout_buffer.buffer_size,
-        config.exp.env.reward,
         config.exp.env.max_steps,
         config.device,
         config.seed,
@@ -109,7 +108,6 @@ def init_trainer(
         scheduler,
         config.device,
         config.exp.reinforce.entropy_weight,
-        config.exp.reinforce.gamma,
         config.exp.reinforce.clip_value,
         config.exp.rollout_buffer.batch_size,
         config.exp.rollout_buffer.batches_per_rollouts,

--- a/src/environment/gym.py
+++ b/src/environment/gym.py
@@ -191,28 +191,7 @@ class EternityEnv(gym.Env):
         infos["just_won"] = self.terminated & ~previous_terminated
         self.max_matches = torch.max(self.max_matches, matches)
 
-        match self.reward_type:
-            case "win":
-                # Only give a reward at the end of the episode.
-                # Either when the environment is done or if the episode is truncated.
-                if not self.truncated:
-                    rewards = matches * infos["just_won"] / self.best_matches
-                else:
-                    rewards = matches * ~self.terminated / self.best_matches
-            case "max":
-                # Only give a reward at the end of the episode.
-                # Either when the environment is done or if the episode is truncated.
-                if not self.truncated:
-                    rewards = self.max_matches * infos["just_won"] / self.best_matches
-                else:
-                    rewards = self.max_matches * ~self.terminated / self.best_matches
-            case "delta":
-                # Give a reward at each step.
-                rewards = (matches - previous_matches) / self.best_matches
-                rewards = rewards * ~previous_terminated
-            case _:
-                raise ValueError(f"Unknown reward type {self.reward_type}.")
-
+        rewards = matches / self.best_matches
         return self.render(), rewards, self.terminated, self.truncated, infos
 
     def roll_tiles(self, tile_ids: torch.Tensor, shifts: torch.Tensor):

--- a/src/reinforce/reinforce.py
+++ b/src/reinforce/reinforce.py
@@ -206,6 +206,7 @@ class Reinforce:
 
         episodes_len = rollout_buffer.mask_buffer.float().sum(dim=1)
         metrics["ep-len/mean"] = episodes_len.mean()
+        metrics["ep-len/max"] = episodes_len.max()
         metrics["ep-len/min"] = episodes_len.min()
         metrics["ep-len/std"] = episodes_len.std()
 

--- a/src/reinforce/reinforce.py
+++ b/src/reinforce/reinforce.py
@@ -4,11 +4,10 @@ from typing import Any
 
 import torch
 import torch.optim as optim
+import wandb
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.nn.utils import clip_grad
 from tqdm import tqdm
-
-import wandb
 
 from ..environment import EternityEnv
 from ..model import CNNPolicy
@@ -204,18 +203,18 @@ class Reinforce:
 
         rollout_buffer = self.do_rollouts()
 
-        returns = RolloutBuffer.cumulative_decay_return(
-            rollout_buffer.reward_buffer, rollout_buffer.mask_buffer, gamma=1.0
-        )
-        returns = returns[:, 0]
-        metrics["return/mean"] = returns.mean()
-        metrics["return/max"] = returns.max()
-        metrics["return/std"] = returns.std()
+        # returns = RolloutBuffer.cumulative_decay_return(
+        #     rollout_buffer.reward_buffer, rollout_buffer.mask_buffer, gamma=1.0
+        # )
+        # returns = returns[:, 0]
+        # metrics["return/mean"] = returns.mean()
+        # metrics["return/max"] = returns.max()
+        # metrics["return/std"] = returns.std()
 
-        # matches = self.env.matches / self.env.best_matches
-        # metrics["matches/mean"] = matches.mean()
-        # metrics["matches/max"] = matches.max()
-        # metrics["matches/std"] = matches.std()
+        matches = self.env.matches / self.env.best_matches
+        metrics["matches/mean"] = matches.mean()
+        metrics["matches/max"] = matches.max()
+        metrics["matches/std"] = matches.std()
 
         episodes_len = rollout_buffer.mask_buffer.float().sum(dim=1)
         metrics["ep-len/mean"] = episodes_len.mean()

--- a/src/reinforce/reinforce.py
+++ b/src/reinforce/reinforce.py
@@ -223,8 +223,7 @@ class Reinforce:
         metrics["ep-len/std"] = episodes_len.std()
 
         # Compute losses.
-        batch_size = min(10 * self.batch_size, self.env.batch_size)
-        sample = rollout_buffer.sample(batch_size)
+        sample = rollout_buffer.sample(self.batch_size)
         losses = self.compute_loss(sample)
         for k, v in losses.items():
             metrics[f"loss/{k}"] = v

--- a/src/reinforce/reinforce.py
+++ b/src/reinforce/reinforce.py
@@ -188,7 +188,7 @@ class Reinforce:
                     metrics = self.evaluate()
                     run.log(metrics)
 
-                if i % 500 == 0 and mode != "disabled":
+                if i % 100 == 0 and mode != "disabled":
                     self.save_model("model.pt")
                     self.env.save_best_env("board.png")
                     run.log(
@@ -212,10 +212,10 @@ class Reinforce:
         metrics["return/max"] = returns.max()
         metrics["return/std"] = returns.std()
 
-        matches = self.env.matches / self.env.best_matches
-        metrics["matches/mean"] = matches.mean()
-        metrics["matches/max"] = matches.max()
-        metrics["matches/std"] = matches.std()
+        # matches = self.env.matches / self.env.best_matches
+        # metrics["matches/mean"] = matches.mean()
+        # metrics["matches/max"] = matches.max()
+        # metrics["matches/std"] = matches.std()
 
         episodes_len = rollout_buffer.mask_buffer.float().sum(dim=1)
         metrics["ep-len/mean"] = episodes_len.mean()

--- a/src/reinforce/reinforce.py
+++ b/src/reinforce/reinforce.py
@@ -23,7 +23,6 @@ class Reinforce:
         scheduler: optim.lr_scheduler.LinearLR,
         device: str,
         entropy_weight: float,
-        gamma: float,
         clip_value: float,
         batch_size: int,
         batches_per_rollouts: int,
@@ -38,7 +37,6 @@ class Reinforce:
         self.scheduler = scheduler
         self.device = device
         self.entropy_weight = entropy_weight
-        self.gamma = gamma
         self.clip_value = clip_value
         self.batch_size = batch_size
         self.total_rollouts = total_rollouts
@@ -79,7 +77,7 @@ class Reinforce:
             states = new_states
             timesteps += 1
 
-        self.rollout_buffer.finalize(self.advantage, self.gamma)
+        self.rollout_buffer.finalize(self.advantage)
 
         return self.rollout_buffer
 

--- a/src/reinforce/reinforce.py
+++ b/src/reinforce/reinforce.py
@@ -211,7 +211,7 @@ class Reinforce:
         # metrics["return/max"] = returns.max()
         # metrics["return/std"] = returns.std()
 
-        matches = self.env.matches / self.env.best_matches
+        matches = self.env.max_matches / self.env.best_matches
         metrics["matches/mean"] = matches.mean()
         metrics["matches/max"] = matches.max()
         metrics["matches/std"] = matches.std()

--- a/src/reinforce/rollout_buffer.py
+++ b/src/reinforce/rollout_buffer.py
@@ -104,9 +104,12 @@ class RolloutBuffer:
 
     def finalize(self, advantage_type: str, gamma: float):
         """Compute the returns and advantages of the trajectories."""
-        self.return_buffer = RolloutBuffer.cumulative_decay_return(
-            self.reward_buffer, self.mask_buffer, gamma
+        self.return_bufer, self.mask_buffer = RolloutBuffer.cumulative_max_cut(
+            self.reward_buffer, self.mask_buffer
         )
+        # self.return_buffer = RolloutBuffer.cumulative_decay_return(
+        #     self.reward_buffer, self.mask_buffer, gamma
+        # )
 
         match advantage_type:
             case "estimated":
@@ -158,7 +161,9 @@ class RolloutBuffer:
         }
 
     @staticmethod
-    def cumulative_max_cut(rewards: torch.Tensor, masks: torch.Tensor):
+    def cumulative_max_cut(
+        rewards: torch.Tensor, masks: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Use a cumulative max over the rewards and cut the episodes that end with
         a lower reward than their cumulative max.
 
@@ -168,6 +173,10 @@ class RolloutBuffer:
                 Shape of [batch_size, max_steps].
             masks: The mask indicating which steps are actual plays.
                 Shape of [batch_size, max_steps].
+
+        ---
+        Returns:
+            The returns and masks of the games.
         """
         # Compute the reversed cumulative max.
         rewards = torch.flip(rewards, dims=(1,))

--- a/src/reinforce/rollout_buffer.py
+++ b/src/reinforce/rollout_buffer.py
@@ -104,7 +104,7 @@ class RolloutBuffer:
 
     def finalize(self, advantage_type: str, gamma: float):
         """Compute the returns and advantages of the trajectories."""
-        self.return_bufer, self.mask_buffer = RolloutBuffer.cumulative_max_cut(
+        self.return_buffer, self.mask_buffer = RolloutBuffer.cumulative_max_cut(
             self.reward_buffer, self.mask_buffer
         )
         # self.return_buffer = RolloutBuffer.cumulative_decay_return(

--- a/src/reinforce/rollout_buffer.py
+++ b/src/reinforce/rollout_buffer.py
@@ -238,9 +238,11 @@ class RolloutBuffer:
         if gamma == 1:
             rewards = torch.flip(rewards, dims=(1,))
             masks = torch.flip(masks, dims=(1,))
-            returns = torch.cumsum(masks * rewards, dim=1)
+            returns = torch.cummax(masks * rewards, dim=1).values
             returns = torch.flip(returns, dims=(1,))
             return returns
+        else:
+            raise NotImplementedError()
 
         # Compute the gamma powers.
         powers = (rewards.shape[1] - 1) - torch.arange(

--- a/src/reinforce/rollout_buffer.py
+++ b/src/reinforce/rollout_buffer.py
@@ -102,14 +102,11 @@ class RolloutBuffer:
         self.pointer += 1
         self.pointer %= self.max_steps
 
-    def finalize(self, advantage_type: str, gamma: float):
+    def finalize(self, advantage_type: str):
         """Compute the returns and advantages of the trajectories."""
         self.return_buffer, self.mask_buffer = RolloutBuffer.cumulative_max_cut(
             self.reward_buffer, self.mask_buffer
         )
-        # self.return_buffer = RolloutBuffer.cumulative_decay_return(
-        #     self.reward_buffer, self.mask_buffer, gamma
-        # )
 
         match advantage_type:
             case "estimated":

--- a/src/reinforce/test_reinforce.py
+++ b/src/reinforce/test_reinforce.py
@@ -55,3 +55,37 @@ def test_cumulative_decay_return(
     assert torch.allclose(
         RolloutBuffer.cumulative_decay_return(rewards, masks, gamma), returns
     )
+
+
+@pytest.mark.parametrize(
+    "rewards, masks, returns, cutted_masks",
+    [
+        (
+            torch.FloatTensor([[2, 1, 1]]),
+            torch.BoolTensor([[True, True, True]]),
+            torch.FloatTensor([[2, 1, 1]]),
+            torch.BoolTensor([[True, False, False]]),
+        ),
+        (
+            torch.FloatTensor([[2, 1, 1], [3, 2, 4]]),
+            torch.BoolTensor([[True, True, True], [True, True, True]]),
+            torch.FloatTensor([[2, 1, 1], [4, 4, 4]]),
+            torch.BoolTensor([[True, False, False], [True, True, True]]),
+        ),
+        (
+            torch.FloatTensor([[2, 1, 1], [3, 2, 4]]),
+            torch.BoolTensor([[True, True, True], [True, True, False]]),
+            torch.FloatTensor([[2, 1, 1], [3, 2, 0]]),
+            torch.BoolTensor([[True, False, False], [True, False, False]]),
+        ),
+    ],
+)
+def test_cumulative_max_cut(
+    rewards: torch.Tensor,
+    masks: torch.Tensor,
+    returns: torch.Tensor,
+    cutted_masks: torch.Tensor,
+):
+    computed_returns, computed_masks = RolloutBuffer.cumulative_max_cut(rewards, masks)
+    assert torch.all(computed_returns == returns)
+    assert torch.all(computed_masks == cutted_masks)


### PR DESCRIPTION
Removed the previous rewards, now the rewards are just the current normalized matches of the states.

During the rollout, the rewards are saved and at the end of an episode, the rollout is cutted after the state having the maximum score over the episode.

Removed the old rewards mechanism, and the gamma factor.