### PR TITLE
Stable implementation of PPO

### DIFF
--- a/configs/exp/hard.yaml
+++ b/configs/exp/hard.yaml
@@ -37,7 +37,6 @@ trainer:
 iterations:
   rollouts: 100
   epochs: -1
-  batches: 100
   batch_size: 5000
 
 checkpoint:

--- a/configs/exp/normal.yaml
+++ b/configs/exp/normal.yaml
@@ -32,7 +32,7 @@ loss:
 
 trainer:
   clip_value: 1.0
-  scramble_size: 0.00
+  scramble_size: 0.50
 
 iterations:
   rollouts: 60

--- a/configs/exp/normal.yaml
+++ b/configs/exp/normal.yaml
@@ -37,7 +37,6 @@ trainer:
 iterations:
   rollouts: 60
   epochs: -1
-  batches: 60
   batch_size: 5000
 
 checkpoint:

--- a/configs/exp/normal.yaml
+++ b/configs/exp/normal.yaml
@@ -32,11 +32,11 @@ loss:
 
 trainer:
   clip_value: 1.0
-  scramble_size: 0.50
+  scramble_size: 0.00
 
 iterations:
   rollouts: 60
-  epochs: -1
+  epochs: 500
   batch_size: 5000
 
 checkpoint:

--- a/configs/exp/normal.yaml
+++ b/configs/exp/normal.yaml
@@ -3,19 +3,19 @@ group: Normal
 
 env:
   path: ./instances/eternity_A.txt
-  batch_size: 10000
+  batch_size: 1000
 
 model:
-  embedding_dim: 64
-  n_heads: 4
-  backbone_layers: 6
-  decoder_layers: 2
+  embedding_dim: 32
+  n_heads: 2
+  backbone_layers: 4
+  decoder_layers: 1
   dropout: 0.05
 
 optimizer:
   optimizer: adamw
   learning_rate: 1.0e-4
-  weight_decay: 1.0e-3
+  weight_decay: 1.0e-2
 
 scheduler:
   warmup_steps: 0
@@ -27,8 +27,8 @@ loss:
   gae_lambda: 0.95
   ppo_clip_ac: 0.30
   ppo_clip_vf: 0.30
-  value_weight: 1.0e-3
-  entropy_weight: 1.0e-3
+  value_weight: 1.0e-0
+  entropy_weight: 1.0e-2
 
 trainer:
   clip_value: 1.0
@@ -36,7 +36,7 @@ trainer:
 
 iterations:
   rollouts: 60
-  epochs: 500
-  batch_size: 5000
+  epochs: 2000
+  batch_size: 1000
 
 checkpoint:

--- a/configs/exp/trivial.yaml
+++ b/configs/exp/trivial.yaml
@@ -36,7 +36,7 @@ trainer:
 
 iterations:
   rollouts: 10
-  epochs: 500
+  epochs: 100
   batch_size: 2500
 
 checkpoint:

--- a/configs/exp/trivial.yaml
+++ b/configs/exp/trivial.yaml
@@ -37,7 +37,6 @@ trainer:
 iterations:
   rollouts: 10
   epochs: 500
-  batches: 10
   batch_size: 2500
 
 checkpoint:

--- a/configs/exp/trivial.yaml
+++ b/configs/exp/trivial.yaml
@@ -3,7 +3,7 @@ group: Trivial A
 
 env:
   path: ./instances/eternity_trivial_A.txt
-  batch_size: 5000
+  batch_size: 500
 
 model:
   embedding_dim: 24
@@ -27,16 +27,16 @@ loss:
   gae_lambda: 0.95
   ppo_clip_ac: 0.10
   ppo_clip_vf: 0.20
-  value_weight: 1.0e-2
-  entropy_weight: 1.0e-2
+  value_weight: 1.0e-0
+  entropy_weight: 1.0e-1
 
 trainer:
-  clip_value: 0.050
+  clip_value: 1.000
   scramble_size: 0.00
 
 iterations:
   rollouts: 10
-  epochs: 100
-  batch_size: 2500
+  epochs: 500
+  batch_size: 500
 
 checkpoint:

--- a/configs/exp/trivial_B.yaml
+++ b/configs/exp/trivial_B.yaml
@@ -32,11 +32,11 @@ loss:
 
 trainer:
   clip_value: 1.0
-  scramble_size: 0.50
+  scramble_size: 0.00
 
 iterations:
   rollouts: 40
-  epochs: 500
+  epochs: 100
   batch_size: 5000
 
 checkpoint:

--- a/configs/exp/trivial_B.yaml
+++ b/configs/exp/trivial_B.yaml
@@ -37,7 +37,6 @@ trainer:
 iterations:
   rollouts: 40
   epochs: 500
-  batches: 40
   batch_size: 5000
 
 checkpoint:

--- a/configs/exp/trivial_B.yaml
+++ b/configs/exp/trivial_B.yaml
@@ -36,7 +36,7 @@ trainer:
 
 iterations:
   rollouts: 40
-  epochs: 100
+  epochs: 500
   batches: 40
   batch_size: 5000
 

--- a/main.py
+++ b/main.py
@@ -130,7 +130,7 @@ def init_replay_buffer(config: DictConfig) -> ReplayBuffer:
     max_size = exp.env.batch_size * exp.iterations.rollouts
     return TensorDictReplayBuffer(
         storage=LazyTensorStorage(max_size=max_size, device=config.device),
-        # sampler=SamplerWithoutReplacement(drop_last=True),
+        sampler=SamplerWithoutReplacement(drop_last=True),
         batch_size=exp.iterations.batch_size,
         pin_memory=True,
     )
@@ -158,7 +158,6 @@ def init_trainer(
         trainer.clip_value,
         trainer.scramble_size,
         iterations.rollouts,
-        iterations.batches,
         iterations.epochs,
     )
 

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from omegaconf import DictConfig, OmegaConf
 from pytorch_optimizer import Lamb, Lion
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torchrl.data import LazyTensorStorage, ReplayBuffer, TensorDictReplayBuffer
+from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
 
 from src.environment import EternityEnv
 from src.model import Policy
@@ -129,6 +130,7 @@ def init_replay_buffer(config: DictConfig) -> ReplayBuffer:
     max_size = exp.env.batch_size * exp.iterations.rollouts
     return TensorDictReplayBuffer(
         storage=LazyTensorStorage(max_size=max_size, device=config.device),
+        # sampler=SamplerWithoutReplacement(drop_last=True),
         batch_size=exp.iterations.batch_size,
         pin_memory=True,
     )

--- a/notes/random.norg
+++ b/notes/random.norg
@@ -137,3 +137,7 @@ version: 1.1.1
   others are also affected. This means that my training was wrong all along (estimation
   of the advantage, value targets, and overall environment length). This problem was
   undetected thanks to an `assert` that was missing in a unit-test.
+
+  Make sure the value agent does not know what actions are sampled. Since my actor needs
+  to know which sub-action is sampled before outputting the rest of the sub-action distributions,
+  the value network can also see them. In this case, training was collapsing at some point.

--- a/notes/random.norg
+++ b/notes/random.norg
@@ -4,7 +4,7 @@ description: Some random thoughts
 authors: pierrotlc
 categories: Notes
 created: 2023-06-04
-updated: 2023-09-19
+updated: 2023-09-20T22:01:22+0100
 version: 1.1.1
 @end
 
@@ -45,6 +45,13 @@ version: 1.1.1
 
   Finally, I have to use it back since i'm training in a never-ending environment.
   To have access to a return estimation, I have to estimate the values using a value function.
+
+  It is advised to have two separate networks for the actor and the critic.
+  After little testing, I have not found so much differences. But I have found a $30%$
+  increase in total time per epoch. This is because during my training a lot of the compute
+  is spent on the model since the rest is pretty well optimized and batched. Note that
+  I did not really spend a lot of time experimenting this. It may be worth to have
+  two small models that are faster than a single big shared model for both actor and critic.
 
 * Reward modeling
   The `win` reward is good because it does not optimize for the number of

--- a/notes/random.norg
+++ b/notes/random.norg
@@ -1,110 +1,139 @@
 @document.meta
 title: random
-description: Some weird facts
+description: Some random thoughts
 authors: pierrotlc
 categories: Notes
 created: 2023-06-04
-updated: 2023-09-16T00:16:32+0100
+updated: 2023-09-19
 version: 1.1.1
 @end
 
 
-* Random thoughts
-** Computing the logprobs with logits and softmax
-   It is not the same to compute the logprobs from the outputted logits
-   and from the softmax distribution.
+* Computing the logprobs with logits and softmax
+  It is not the same to compute the logprobs from the outputted logits
+  and from the softmax distribution.
 
-   @code python3
-   distrib = torch.distributions.Categorical(logits=logits)
-   logprobs = distrib.log_prob(actions)
-   @end
+  @code python3
+  distrib = torch.distributions.Categorical(logits=logits)
+  logprobs = distrib.log_prob(actions)
+  @end
 
-   @code python3
-   distrib = torch.distributions.Categorical(probs=torch.softmax(logits))
-   logprobs = distrib.log_prob(actions)
-   @end
+  @code python3
+  distrib = torch.distributions.Categorical(probs=torch.softmax(logits))
+  logprobs = distrib.log_prob(actions)
+  @end
 
-   The second one is the one that should be used.
-   I think that the first one is either wrong or inefficient.
+  The second one is the one that should be used.
+  I think that the first one is either wrong or inefficient.
 
-** Instability in the training
-   The reward normalization can lead to instabilities in the training.
-   It is important to take this into account and to use a rather large epsilon.
+* Instability in the training
+  The reward normalization can lead to instabilities in the training.
+  It is important to take this into account and to use a rather large epsilon.
 
-   A recurrent policy is also hard to train since it can lead to huge BPTT
-   gradient updates. To counter this, I regularly stop the gradient during the rollout.
+  A recurrent policy is also hard to train since it can lead to huge BPTT
+  gradient updates. To counter this, I regularly stop the gradient during the rollout.
+  Would it be feasible to stop the gradient at each step? This would make the use of
+  a replay buffer easier.
 
-** Actor/critic
-   My implementation seems to not be working so well, or at most to do
-   equally as the base implementation. It may be because the current reward
-   estimation is already good enough thanks to the high batch MC sampling.
+* Actor/critic
+  My implementation seems to not be working so well, or at most to do
+  equally as the base implementation. It may be because the current reward
+  estimation is already good enough thanks to the high batch MC sampling.
 
-   It also introduces a lot of hyperparameters to tune, so I decided to
-   remove it.
+  It also introduces a lot of hyperparameters to tune, so I decided to
+  remove it.
 
-   Finally, I have to use it back since i'm training in a never-ending environment.
-   To have access to a return estimation, I have to estimate the values using a value function.
+  Finally, I have to use it back since i'm training in a never-ending environment.
+  To have access to a return estimation, I have to estimate the values using a value function.
 
+* Reward modeling
+  The `win` reward is good because it does not optimize for the number of
+  steps to win, nor for intermediate easy rewards. But it has a problem:
+  long rollouts tend to all collapse to the mean state. The mode is not
+  rewarded for the maximum intermediate state.
 
-** Reward modeling
-   The `win` reward is good because it does not optimize for the number of
-   steps to win, nor for intermediate easy rewards. But it has a problem:
-   long rollouts tend to all collapse to the mean state. The mode is not
-   rewarded for the maximum intermediate state.
+  The new reward called `max-cut` provides a more stable training, and is
+  way more sample efficient.
 
-   The new reward called `max-cut` provides a more stable training, and is
-   way more sample efficient.
+* Replay buffer
+  The replay buffer is primarily used to be more sample efficient by reusing past
+  samples during the training. But in my case, collecting the rollout samples is
+  pretty fast so that I can do without such a buffer.
 
-** Rollout buffer
-   The rollout buffer is primarily used to be more sample efficient by reusing past
-   samples during the training. But in my case, collecting the rollout samples is
-   pretty fast so that I can do without such a buffer.
+  Being able to train without a replay buffer is nice because it makes it easier
+  to implement tricky policies such as RNNs (useful for planning).
+  On the other hand, a replay buffer can be useful to implement tricky sampling policies
+  such as the prioritized experience replay.
 
-   Being able to train without a rollout buffer is nice because it makes it easier
-   to implement tricky policies such as RNNs (useful for planning).
+* Rotation equivariant
+  The game is strictly rotation equivariant, meaning that the model should output
+  the same rotated actions to a rotated board. This can be integrated in the algorithm
+  in multiple ways:
+  ~ Properly randomize the board state, so that the model sees a lot of diverse board
+    states and learns to be equivariant by itself.
+  ~ Add a regularization loss that directly enforce the model to be equivariant to
+    rotations of the board.
+  ~ Design the model so that it is naturally equivariant to rotations.
 
-** Rotation equivariant
-   The game is strictly rotation equivariant, meaning that the model should output
-   the same rotated actions to a rotated board. This can be integrated in the algorithm
-   in multiple ways:
-   ~ Properly randomize the board state, so that the model sees a lot of diverse board
-     states and learns to be equivariant by itself.
-   ~ Add a regularization loss that directly enforce the model to be equivariant to
-     rotations of the board.
-   ~ Design the model so that it is naturally equivariant to rotations.
+  Note that the game is also strictly equivariant to horizontal and vertical flips.
 
-   Note that the game is also strictly equivariant to horizontal and vertical flips.
+  The best thing to do is to design the model to be equivariant to rotations and flips.
+  To do so, the encoder can use a {https://arxiv.org/abs/1602.07576}[group equivariant CNN]
+  and/or a simple transformer encoder (with a symmetrical equivariant positional encoding, if used).
+  The decoder can use a pointer network to select the tile to swap, and since the rolls
+  are relative to the current tile placement, it can be done with a simple linear layer.
 
-   The best thing to do is to design the model to be equivariant to rotations and flips.
-   To do so, the encoder can use a {https://arxiv.org/abs/1602.07576}[group equivariant CNN]
-   and/or a simple transformer encoder (with a symmetrical equivariant positional encoding, if used).
-   The decoder can use a pointer network to select the tile to swap, and since the rolls
-   are relative to the current tile placement, it can be done with a simple linear layer.
+* Parallel exploration
+  Using pure MCTS is not cool because it is hard to implement in parallel. Another way
+  of exploring potential futures and to plan is to duplicate each instance and to do
+  batched steps forward. It can be used to estimate what the next best action is.
+  This process can also be repeated multiple times to trade time for memory.
 
-** Parallel exploration
-   Using pure MCTS is not cool because it is hard to implement in parallel. Another way
-   of exploring potential futures and to plan is to duplicate each instance and to do
-   batched steps forward. It can be used to estimate what the next best action is.
-   This process can also be repeated multiple times to trade time for memory.
+* Potentially never-ending episodes
+  A proper way to train the model is to use never-ending episodes. Doing so,
+  the return is impossible to truly compute with MCTS sampling, but it can
+  be estimated with a value network.
 
-** Potentially never-ending episodes
-   A proper way to train the model is to use never-ending episodes. Doing so,
-   the return is impossible to truly compute with MCTS sampling, but it can
-   be estimated with a value network.
+  But it is hard to train a value network in my environment since the model
+  can kind of go back in time. By switching pieces, it is easy to go to a previously
+  encountered state. The value network has to take into account this fact, and
+  the training becomes harder.
 
-   But it is hard to train a value network in my environment since the model
-   can kind of go back in time. By switch pieces it is easy to go to a previously
-   encountered state. The value network has to take into account this fact, and
-   the training becomes harder.
+  The reward is also very important. A good reward shaping will make it easier
+  for the model to quickly understand what the goal is.
 
-   The reward is also very important. A good reward shaping will make it easier
-   for the model to quickly understand what the goal is.
+* About on-policy learning and exploration
+  It's harder to implement a forced exploration or exploitation when using an on-policy
+  algorithm. You can't use a tempered softmax, epsilon-greedy or a mix of samplings.
+  That's a shame!
 
-** About on-policy learning and exploration
-   It's harder to implement a forced exploration or exploitation when using an on-policy
-   algorithm. You can't use a tempered softmax, epsilon-greedy or a mix of samplings.
-   That's a shame!
+  It could be interesting to sample the tile selection with a tempered softmax and
+  the tile rotation with epsilon-greedy.
 
-   It could be interesting to sample the tile selection with a tempered softmax and
-   the tile rotation with epsilon-greedy.
+* Resetting an environment during rollout collection
+  I met some instabilities when training on small puzzles, and I couldn't find where
+  they could come from.
+  The following blog post {https://iclr-blog-track.github.io/2022/03/25/ppo-implementation-details/}[37 implementation details of PPO] gave me the answer.
 
+  When collecting experience replay samples, you /should/ reset the environment once an
+  environment is either done or truncated. Doing this ensure that your replay buffer will
+  always have the same fixed size. My instability problem was due to the fact that
+  once the model was acing the small puzzle it was looking at, it started to be so good
+  that each environment in the batch was done very quickly. This lead to a replay buffer
+  that is smaller than what was expected and my model would be trained on the same samples
+  many times before collecting new samples (because I used a fixed number of iterations
+  over the buffer with random sampling with replacement).
+
+  All and all, not resetting the environment lead to an unstable training due to the fact
+  that my on-policy algorithm was not really on-policy anymore, since samples were used
+  many times during training.
+
+  Note that to implement this you need to properly take into account the done and truncated
+  flags of the rollout when computing advantages and value targets. Moreover, doing this
+  efficiently on GPU is hard.
+
+* RL bugs are hard
+  Many months later, I found out that when I reset some specific envs of the batch, the
+  others are also affected. This means that my training was wrong all along (estimation
+  of the advantage, value targets, and overall environment length). This problem was
+  undetected thanks to an `assert` that was missing in a unit-test.

--- a/notes/todo.norg
+++ b/notes/todo.norg
@@ -14,9 +14,10 @@ updated: 2023-09-16T01:26:36+0100
   -- ( ) Separate actor and critic.
   -- (x) Reset terminated envs during rollouts.
   -- ( ) Handle GAE multiple terminated envs in a batch sample.
-  -- ( ) Handle truncated envs.
+  -- (x) Handle truncated envs.
   -- (x) Remove masks.
   -- ( ) Sample without replacement during training.
+  -- ( ) Why the value target is going above 1?
   - Curriculum learning.
   -- trivial < 2x2 randoms < trivial_B < 3x3 randoms < ...
   -- Randomly sample problem difficulties.

--- a/notes/todo.norg
+++ b/notes/todo.norg
@@ -12,7 +12,10 @@ updated: 2023-09-16T01:26:36+0100
   -- {https://iclr-blog-track.github.io/2022/03/25/ppo-implementation-details/}
   -- ( ) Try a pure on-policy learning.
   -- ( ) Separate actor and critic.
-  -- ( ) Reset terminated envs during rollouts.
+  -- (x) Reset terminated envs during rollouts.
+  -- ( ) Handle GAE multiple terminated envs in a batch sample.
+  -- ( ) Handle truncated envs.
+  -- (x) Remove masks.
   -- ( ) Sample without replacement during training.
   - Curriculum learning.
   -- trivial < 2x2 randoms < trivial_B < 3x3 randoms < ...

--- a/notes/todo.norg
+++ b/notes/todo.norg
@@ -13,11 +13,11 @@ updated: 2023-09-16T01:26:36+0100
   -- ( ) Try a pure on-policy learning.
   -- ( ) Separate actor and critic.
   -- (x) Reset terminated envs during rollouts.
-  -- ( ) Handle GAE multiple terminated envs in a batch sample.
+  -- (x) Handle GAE multiple terminated envs in a batch sample.
   -- (x) Handle truncated envs.
   -- (x) Remove masks.
-  -- ( ) Sample without replacement during training.
-  -- ( ) Why the value target is going above 1?
+  -- (x) Sample without replacement during training.
+  -- (x) Why the value target is going above 1?
   - Curriculum learning.
   -- trivial < 2x2 randoms < trivial_B < 3x3 randoms < ...
   -- Randomly sample problem difficulties.

--- a/notes/todo.norg
+++ b/notes/todo.norg
@@ -3,15 +3,15 @@ title: todo
 authors: pierrotlc
 categories: notes
 created: 2023-03-08
-updated: 2023-09-16T01:26:36+0100
+updated: 2023-09-20T22:03:36+0100
 @end
 
 * TODO
   - Do not randomly reset the environments before each rollout.
   - Why is the training unstable?
-  -- {https://iclr-blog-track.github.io/2022/03/25/ppo-implementation-details/}
+  -- (x) {https://iclr-blog-track.github.io/2022/03/25/ppo-implementation-details/}
   -- ( ) Try a pure on-policy learning.
-  -- ( ) Separate actor and critic.
+  -- (x) Separate actor and critic.
   -- (x) Reset terminated envs during rollouts.
   -- (x) Handle GAE multiple terminated envs in a batch sample.
   -- (x) Handle truncated envs.

--- a/src/environment/gym.py
+++ b/src/environment/gym.py
@@ -234,7 +234,7 @@ class EternityEnv(gym.Env):
         total_shifts[tile_ids + offsets] = shifts
 
         self.instances = rearrange(self.instances, "b c h w -> (b h w) c")
-        self.instances = self.batched_roll(self.instances, total_shifts)
+        self.instances = EternityEnv.batched_roll(self.instances, total_shifts)
         self.instances = rearrange(
             self.instances,
             "(b h w) c -> b c h w",
@@ -311,18 +311,21 @@ class EternityEnv(gym.Env):
                 Shape of [instances,].
         """
         # Scrambles the tiles.
-        self.instances = rearrange(self.instances, "b c h w -> b (h w) c")
+        self.instances = rearrange(self.instances, "b s h w -> b (h w) s")
         permutations = torch.arange(start=0, end=self.n_pieces, device=self.device)
-        permutations = repeat(permutations, "p -> b p", b=self.batch_size)
+        permutations = repeat(
+            permutations, "p -> b p s", b=self.batch_size, s=N_SIDES
+        ).clone()
+
         for instance_id in instance_ids:
-            permutations[instance_id] = torch.randperm(
-                self.n_pieces, generator=self.rng, device=self.device
-            )
-        permutations = repeat(permutations, "b p -> b p c", c=self.instances.shape[2])
+            perm = torch.randperm(self.n_pieces, generator=self.rng, device=self.device)
+            perm = repeat(perm, "p -> p s", s=N_SIDES)
+            permutations[instance_id] = perm
+
         self.instances = torch.gather(self.instances, dim=1, index=permutations)
 
         # Randomly rolls the tiles.
-        self.instances = rearrange(self.instances, "b p c -> (b p) c")
+        self.instances = rearrange(self.instances, "b p s -> (b p) s")
         shifts = torch.zeros(
             self.batch_size * self.n_pieces, dtype=torch.long, device=self.device
         )
@@ -336,10 +339,10 @@ class EternityEnv(gym.Env):
             generator=self.rng,
             device=self.device,
         )
-        self.instances = self.batched_roll(self.instances, shifts)
+        self.instances = EternityEnv.batched_roll(self.instances, shifts)
         self.instances = rearrange(
             self.instances,
-            "(b h w) c -> b c h w",
+            "(b h w) s -> b s h w",
             b=self.batch_size,
             h=self.board_size,
             w=self.board_size,

--- a/src/environment/gym.py
+++ b/src/environment/gym.py
@@ -176,6 +176,7 @@ class EternityEnv(gym.Env):
             terminated: Whether the environments are terminated (won).
                 Shape of [batch_size,].
             truncated: Whether the environments are truncated (max steps reached).
+                Shape of [batch_size,].
             infos: Additional infos.
                 - `just_won`: Whether the environments has just been won.
         """
@@ -207,8 +208,9 @@ class EternityEnv(gym.Env):
         self.terminated |= matches == self.best_matches_possible
         infos["just-won"] = self.terminated & ~previously_terminated
         self.total_won += infos["just-won"].sum().cpu().item()
+        truncated = torch.zeros(self.batch_size, dtype=torch.bool, device=self.device)
 
-        return self.render(), rewards, self.terminated, False, infos
+        return self.render(), rewards, self.terminated, truncated, infos
 
     def roll_tiles(self, tile_ids: torch.Tensor, shifts: torch.Tensor):
         """Rolls tiles at the given ids for the given shifts.

--- a/src/environment/test_env.py
+++ b/src/environment/test_env.py
@@ -145,7 +145,7 @@ def test_batch_scramble(instance_path: str):
         if instance_id in changed_instances:
             continue
 
-        torch.all(env.instances[instance_id] == reference)
+        assert torch.all(env.instances[instance_id] == reference)
 
 
 def test_batch_roll():

--- a/src/policy_gradient/loss.py
+++ b/src/policy_gradient/loss.py
@@ -11,7 +11,7 @@ class PPOLoss(nn.Module):
     Also computes the advantages using the GAE algorithm.
 
     ---
-    Args:
+    Parameters:
         value_weight: The weight of the value loss.
         entropy_weight: The weight of the entropy loss.
         gamma: The discount factor.

--- a/src/policy_gradient/rollout.py
+++ b/src/policy_gradient/rollout.py
@@ -125,7 +125,7 @@ def split_reset_rollouts(traces: TensorDictBase) -> TensorDictBase:
             dtype=tensor.dtype,
             device=tensor.device,
         )
-        split_tensor[masks] = tensor
+        split_tensor[masks] = einops.rearrange(tensor, "b s ... -> (b s) ...")
 
         split_traces[name] = split_tensor
 

--- a/src/policy_gradient/rollout.py
+++ b/src/policy_gradient/rollout.py
@@ -127,7 +127,6 @@ def split_reset_rollouts(traces: TensorDictBase) -> TensorDictBase:
             device=tensor.device,
         )
         split_tensor[masks] = einops.rearrange(tensor, "b s ... -> (b s) ...")
-
         split_traces[name] = split_tensor
 
     split_traces["masks"] = masks

--- a/src/policy_gradient/rollout.py
+++ b/src/policy_gradient/rollout.py
@@ -57,7 +57,7 @@ def rollout(
     traces["next-values"] = torch.concat(
         (traces["values"][:, 1:], final_values.unsqueeze(1)), dim=1
     )
-    # TODO: Handle the next-values that are of different episodes within the rollout sample.
+    traces["next-values"] *= traces["dones"] | traces["truncated"]
 
     return TensorDict(traces, batch_size=traces["states"].shape[0], device=env.device)
 

--- a/src/policy_gradient/test_policy_gradient.py
+++ b/src/policy_gradient/test_policy_gradient.py
@@ -1,7 +1,8 @@
 import pytest
 import torch
+from tensordict import TensorDict
 
-from .rollout import cumulative_decay_return
+from .rollout import cumulative_decay_return, split_reset_rollouts
 
 
 @pytest.mark.parametrize(
@@ -52,3 +53,17 @@ def test_cumulative_decay_return(
     returns: torch.Tensor,
 ):
     assert torch.allclose(cumulative_decay_return(rewards, masks, gamma), returns)
+
+
+@pytest.mark.parametrize(
+    "traces",
+    [
+        {
+            "dones": torch.BoolTensor([[False, False, True]]),
+            "truncated": torch.BoolTensor([[False, False, False]]),
+        },
+    ],
+)
+def test_split_reset_rollouts(traces: dict):
+    traces = TensorDict(traces, batch_size=traces["dones"].shape[0], device="cpu")
+    split_reset_rollouts(traces)

--- a/src/policy_gradient/test_policy_gradient.py
+++ b/src/policy_gradient/test_policy_gradient.py
@@ -66,7 +66,7 @@ def test_cumulative_decay_return(
             {
                 "dones": torch.BoolTensor([[False, False, True]]),
                 "truncated": torch.BoolTensor([[False, False, False]]),
-                "masks": torch.BoolTensor([[True, True, True]]),
+                "masks": torch.BoolTensor([[True, True, False]]),
             },
         ),
         (

--- a/src/policy_gradient/test_policy_gradient.py
+++ b/src/policy_gradient/test_policy_gradient.py
@@ -56,18 +56,94 @@ def test_cumulative_decay_return(
 
 
 @pytest.mark.parametrize(
-    "traces",
+    "traces,split_traces",
     [
-        {
-            "dones": torch.BoolTensor([[False, False, True]]),
-            "truncated": torch.BoolTensor([[False, False, False]]),
-        },
-        {
-            "dones": torch.BoolTensor([[False, False, True]]),
-            "truncated": torch.BoolTensor([[False, False, False]]),
+        (
+            {
+                "dones": torch.BoolTensor([[False, False, True]]),
+                "truncated": torch.BoolTensor([[False, False, False]]),
             },
+            {
+                "dones": torch.BoolTensor([[False, False, True]]),
+                "truncated": torch.BoolTensor([[False, False, False]]),
+                "masks": torch.BoolTensor([[True, True, True]]),
+            },
+        ),
+        (
+            {
+                "dones": torch.BoolTensor([[False, False, False]]),
+                "truncated": torch.BoolTensor([[True, False, False]]),
+            },
+            {
+                "dones": torch.BoolTensor(
+                    [
+                        [False, False, False],
+                        [False, False, False],
+                    ]
+                ),
+                "truncated": torch.BoolTensor(
+                    [
+                        [True, False, False],
+                        [False, False, False],
+                    ]
+                ),
+                "masks": torch.BoolTensor(
+                    [
+                        [True, False, False],
+                        [True, True, False],
+                    ]
+                ),
+            },
+        ),
+        (
+            {
+                "dones": torch.BoolTensor([[False, False, False]]),
+                "truncated": torch.BoolTensor([[True, False, False]]),
+                "rewards": torch.FloatTensor([[1.0, 3.0, 2.0]]),
+                "actions": torch.LongTensor([[[0, 1], [3, 4], [1, 4]]]),
+            },
+            {
+                "dones": torch.BoolTensor(
+                    [
+                        [False, False, False],
+                        [False, False, False],
+                    ]
+                ),
+                "truncated": torch.BoolTensor(
+                    [
+                        [True, False, False],
+                        [False, False, False],
+                    ]
+                ),
+                "rewards": torch.FloatTensor(
+                    [
+                        [1.0, 0.0, 0.0],
+                        [3.0, 2.0, 0.0],
+                    ]
+                ),
+                "actions": torch.LongTensor(
+                    [
+                        [[0, 1], [0, 0], [0, 0]],
+                        [[3, 4], [1, 4], [0, 0]],
+                    ]
+                ),
+                "masks": torch.BoolTensor(
+                    [
+                        [True, False, False],
+                        [True, True, False],
+                    ]
+                ),
+            },
+        ),
     ],
 )
-def test_split_reset_rollouts(traces: dict):
+def test_split_reset_rollouts(traces: dict, split_traces: dict):
     traces = TensorDict(traces, batch_size=traces["dones"].shape[0], device="cpu")
-    split_reset_rollouts(traces)
+    traces = split_reset_rollouts(traces)
+
+    for name in split_traces.keys():
+        assert torch.all(split_traces[name] == traces[name])
+
+    split_traces_keys = set(split_traces.keys())
+    traces_keys = set(traces.keys())
+    assert split_traces_keys == traces_keys

--- a/src/policy_gradient/test_policy_gradient.py
+++ b/src/policy_gradient/test_policy_gradient.py
@@ -66,7 +66,7 @@ def test_cumulative_decay_return(
             {
                 "dones": torch.BoolTensor([[False, False, True]]),
                 "truncated": torch.BoolTensor([[False, False, False]]),
-                "masks": torch.BoolTensor([[True, True, False]]),
+                "masks": torch.BoolTensor([[True, True, True]]),
             },
         ),
         (

--- a/src/policy_gradient/test_policy_gradient.py
+++ b/src/policy_gradient/test_policy_gradient.py
@@ -62,6 +62,10 @@ def test_cumulative_decay_return(
             "dones": torch.BoolTensor([[False, False, True]]),
             "truncated": torch.BoolTensor([[False, False, False]]),
         },
+        {
+            "dones": torch.BoolTensor([[False, False, True]]),
+            "truncated": torch.BoolTensor([[False, False, False]]),
+            },
     ],
 )
 def test_split_reset_rollouts(traces: dict):

--- a/src/policy_gradient/trainer.py
+++ b/src/policy_gradient/trainer.py
@@ -172,7 +172,7 @@ class Trainer:
         metrics["matches/mean"] = matches.mean()
         metrics["matches/max"] = matches.max()
         metrics["matches/min"] = matches.min()
-        metrics["matches/hist"] = wandb.Histogram(matches.cpu().numpy())
+        metrics["matches/hist"] = wandb.Histogram(matches.cpu())
         metrics["matches/best"] = (
             self.env.best_matches_found / self.env.best_matches_possible
         )
@@ -183,10 +183,8 @@ class Trainer:
         batch = batch.to(self.device)
         metrics |= self.loss(batch, self.model)
         metrics["loss/learning-rate"] = self.scheduler.get_last_lr()[0]
-        metrics["metrics/value-targets"] = wandb.Histogram(
-            batch["value-targets"].cpu().numpy()
-        )
-        metrics["metrics/n_steps"] = wandb.Histogram(self.env.n_steps.cpu().numpy())
+        metrics["metrics/value-targets"] = wandb.Histogram(batch["value-targets"].cpu())
+        metrics["metrics/n_steps"] = wandb.Histogram(self.env.n_steps.cpu())
 
         # Compute the gradient mean and maximum values.
         metrics["loss/total"].backward()

--- a/src/policy_gradient/trainer.py
+++ b/src/policy_gradient/trainer.py
@@ -66,15 +66,11 @@ class Trainer:
         )
         self.loss.advantages(traces)
 
-        # Flatten the batch x steps dimensions and remove the masked steps.
+        # Flatten the batch x steps dimensions.
         samples = dict()
-        masks = einops.rearrange(traces["masks"], "b d -> (b d)")
         for name, tensor in traces.items():
-            if name == "masks":
-                continue
-
             tensor = einops.rearrange(tensor, "b d ... -> (b d) ...")
-            samples[name] = tensor[masks]
+            samples[name] = tensor
 
         samples = TensorDict(
             samples, batch_size=samples["states"].shape[0], device=self.device

--- a/src/policy_gradient/trainer.py
+++ b/src/policy_gradient/trainer.py
@@ -31,7 +31,6 @@ class Trainer:
         clip_value: float,
         scramble_size: float,
         rollouts: int,
-        batches: int,
         epochs: int,
     ):
         self.env = env
@@ -42,7 +41,6 @@ class Trainer:
         self.replay_buffer = replay_buffer
         self.clip_value = clip_value
         self.rollouts = rollouts
-        self.batches = batches
         self.epochs = epochs
 
         self.scramble_size = int(scramble_size * self.env.batch_size)
@@ -145,13 +143,13 @@ class Trainer:
                 self.model.train()
                 self.do_rollouts(sampling_mode="softmax", disable_logs=disable_logs)
 
-                for _ in tqdm(
-                    range(self.batches),
+                for batch in tqdm(
+                    self.replay_buffer,
+                    total=len(self.replay_buffer) // self.replay_buffer._batch_size,
                     desc="Batch",
                     leave=False,
                     disable=disable_logs,
                 ):
-                    batch = self.replay_buffer.sample()
                     self.do_batch_update(batch)
 
                 self.scheduler.step()


### PR DESCRIPTION
Now always collects a full replay buffer at each rollouts. This can be done because once a puzzle is solved by the model during the rollout, it is reset. By doing this I have to take care when computing the GAE. This is why now there's a new function called `split_reset_rollouts` that effectively split all rollouts that have either a done or a truncated event. As usual, this operation is done at the batch level, on GPU.

There's also a bug that was there for maybe 3 months or something. When I reset some specific envs, there was an issue where all the envs (even those that are supposed to be unchanged) where scrambled. This is now fix.

This PR is inspired by [this blogpost](https://iclr-blog-track.github.io/2022/03/25/ppo-implementation-details/). I have searched for many details in my implementation that I could add. I hope that I have now a proper PPO that is working.