### PR TITLE
Go back to perpetual search

### DIFF
--- a/configs/exp/normal.yaml
+++ b/configs/exp/normal.yaml
@@ -4,7 +4,7 @@ group: Normal
 env:
   path: ./instances/eternity_A.txt
   batch_size: 128
-  scramble_size: 1.00
+  episode_length: inf
 
 model:
   embedding_dim: 16
@@ -19,7 +19,7 @@ optimizer:
   weight_decay: 1.0e-2
 
 loss:
-  gamma: 1.00
+  gamma: 0.99
   gae_lambda: 0.95
   ppo_clip_ac: 0.20
   ppo_clip_vf: 0.20
@@ -31,6 +31,7 @@ trainer:
   epochs: 1
   batch_size: 128
   rollouts: 60
+  reset_proportion: 0.20
   clip_value: 1.0
 
 checkpoint:

--- a/configs/exp/normal.yaml
+++ b/configs/exp/normal.yaml
@@ -27,11 +27,11 @@ loss:
   entropy_weight: 1.0e-1
 
 trainer:
-  episodes: -1
+  episodes: 15000
   epochs: 1
   batch_size: 128
   rollouts: 60
-  reset_proportion: 0.20
+  reset_proportion: 0.75
   clip_value: 1.0
 
 checkpoint:

--- a/configs/exp/trivial.yaml
+++ b/configs/exp/trivial.yaml
@@ -4,7 +4,7 @@ group: Trivial A
 env:
   path: ./instances/eternity_trivial_A.txt
   batch_size: 128
-  scramble_size: 1.00
+  episode_length: inf
 
 model:
   embedding_dim: 8
@@ -19,7 +19,7 @@ optimizer:
   weight_decay: 1.0e-2
 
 loss:
-  gamma: 1.00
+  gamma: 0.99
   gae_lambda: 0.95
   ppo_clip_ac: 0.10
   ppo_clip_vf: 1.00
@@ -31,6 +31,7 @@ trainer:
   epochs: 3
   batch_size: 128
   rollouts: 10
+  reset_proportion: 0.20
   clip_value: 1.0
 
 checkpoint:

--- a/configs/exp/trivial_B.yaml
+++ b/configs/exp/trivial_B.yaml
@@ -14,24 +14,24 @@ model:
   dropout: 0.00
 
 optimizer:
-  learning_rate: 3.0e-4
   optimizer: adamw
+  learning_rate: 3.0e-4
   weight_decay: 1.0e-2
 
 loss:
   gamma: 0.99
   gae_lambda: 0.95
   ppo_clip_ac: 0.30
-  ppo_clip_vf: 1.00
-  value_weight: 0.01
+  ppo_clip_vf: 0.30
+  value_weight: 0.1
   entropy_weight: 1.0e-1
 
 trainer:
-  episodes: 1000
-  epochs: 3
+  episodes: 4000
+  epochs: 1
   batch_size: 128
   rollouts: 30
-  reset_proportion: 0.50
+  reset_proportion: 0.75
   clip_value: 1.0
 
 checkpoint:

--- a/configs/exp/trivial_B.yaml
+++ b/configs/exp/trivial_B.yaml
@@ -4,7 +4,7 @@ group: Trivial B
 env:
   path: ./instances/eternity_trivial_B.txt
   batch_size: 128
-  scramble_size: 1.00
+  episode_length: inf
 
 model:
   embedding_dim: 12
@@ -19,18 +19,19 @@ optimizer:
   weight_decay: 1.0e-2
 
 loss:
-  gamma: 1.00
+  gamma: 0.99
   gae_lambda: 0.95
   ppo_clip_ac: 0.30
   ppo_clip_vf: 1.00
-  value_weight: 1.0
-  entropy_weight: 1.0e-2
+  value_weight: 0.01
+  entropy_weight: 1.0e-1
 
 trainer:
-  episodes: 250
+  episodes: 1000
   epochs: 3
   batch_size: 128
   rollouts: 30
+  reset_proportion: 0.50
   clip_value: 1.0
 
 checkpoint:

--- a/main.py
+++ b/main.py
@@ -37,11 +37,17 @@ def cleanup_distributed():
 def init_env(config: DictConfig) -> EternityEnv:
     """Initialize the environment."""
     env = config.exp.env
+    if not isinstance(env.episode_length, int):
+        assert env.episode_length in {
+            "inf",
+            "+inf",
+        }, "Provide either an integer or 'inf'."
+        env.episode_length = float(env.episode_length)
+
     return EternityEnv.from_file(
         env.path,
-        config.exp.trainer.rollouts,
+        env.episode_length,
         env.batch_size,
-        env.scramble_size,
         config.device,
         config.seed,
     )
@@ -180,6 +186,7 @@ def init_trainer(
         trainer.episodes,
         trainer.epochs,
         trainer.rollouts,
+        trainer.reset_proportion,
     )
 
 

--- a/shell.nix
+++ b/shell.nix
@@ -20,6 +20,7 @@ in
       cudaPackages.cudatoolkit
       cudaPackages.cudnn
       just
+      pdm
     ]);
     runScript = "bash";
   }).env

--- a/src/mcts/test_mcts.py
+++ b/src/mcts/test_mcts.py
@@ -12,7 +12,6 @@ def env_mockup(instance_path: str = "./instances/eternity_A.txt") -> EternityEnv
         instance_path,
         episode_length=10,
         batch_size=2,
-        scramble_size=1.0,
         device="cpu",
         seed=0,
     )

--- a/src/mcts/tree.py
+++ b/src/mcts/tree.py
@@ -293,6 +293,7 @@ class MCTSTree:
 
         # If an env is done, we take the value of the final board instead of
         # the prediction of the critic.
+        # WARNING: How to properly decide the value of a terminated env?
         values = dones * envs.best_matches / envs.best_possible_matches + ~dones * values
 
         actions = rearrange(actions, "(b c) a -> b c a", c=self.n_childs)

--- a/src/mcts/tree.py
+++ b/src/mcts/tree.py
@@ -285,16 +285,16 @@ class MCTSTree:
                 Shape of [batch_size, n_childs].
         """
         envs = EternityEnv.duplicate_interleave(envs, self.n_childs)
-        actions, *_ = self.policy(
-            envs.render(), envs.best_boards, envs.n_steps, sampling_mode="softmax"
-        )
+        actions, *_ = self.policy(envs.render(), sampling_mode="softmax")
         boards, _, dones, truncated, _ = envs.step(actions)
-        values = self.critic(boards, envs.best_boards, envs.n_steps)
+        values = self.critic(boards)
 
         # If an env is done, we take the value of the final board instead of
         # the prediction of the critic.
         # WARNING: How to properly decide the value of a terminated env?
-        values = dones * envs.best_matches / envs.best_possible_matches + ~dones * values
+        values = (
+            dones * envs.best_matches / envs.best_possible_matches + ~dones * values
+        )
 
         actions = rearrange(actions, "(b c) a -> b c a", c=self.n_childs)
         values = rearrange(values, "(b c) -> b c", c=self.n_childs)

--- a/src/model/critic.py
+++ b/src/model/critic.py
@@ -45,8 +45,7 @@ class Critic(nn.Module):
             dtype=torch.long,
             device=device,
         )
-        n_steps = torch.zeros(1, dtype=torch.long, device=device)
-        return (tiles, tiles, n_steps)
+        return (tiles,)
 
     def summary(self, device: str):
         """Torchinfo summary."""
@@ -62,8 +61,6 @@ class Critic(nn.Module):
     def forward(
         self,
         tiles: torch.Tensor,
-        best_tiles: torch.Tensor,
-        n_steps: torch.Tensor,
     ) -> torch.Tensor:
         """Predict the actions and value for the given game states.
 
@@ -71,10 +68,6 @@ class Critic(nn.Module):
         Args:
             tiles: The game state.
                 Long tensor of shape [batch_size, N_SIDES, board_height, board_width].
-            best_tiles: The game best state.
-                Long tensor of shape [batch_size, N_SIDES, board_height, board_width].
-            n_steps: Number of steps of each game.
-                Long tensor of shape [batch_size,].
             sampling_mode: The sampling mode of the actions.
                 One of ["sample", "greedy"].
             sampled_actions: The already sampled actions, if any.
@@ -92,7 +85,7 @@ class Critic(nn.Module):
                 Shape of [batch_size,].
         """
         batch_size = tiles.shape[0]
-        tiles = self.backbone(tiles, best_tiles, n_steps)
+        tiles = self.backbone(tiles)
         queries = repeat(self.value_query, "e -> b e", b=batch_size)
         values = self.estimate_value(tiles, queries)
         return values

--- a/src/model/policy.py
+++ b/src/model/policy.py
@@ -52,8 +52,7 @@ class Policy(nn.Module):
             dtype=torch.long,
             device=device,
         )
-        n_steps = torch.zeros(1, dtype=torch.long, device=device)
-        return (tiles, tiles, n_steps)
+        return (tiles,)
 
     def summary(self, device: str):
         """Torchinfo summary."""
@@ -69,8 +68,6 @@ class Policy(nn.Module):
     def forward(
         self,
         tiles: torch.Tensor,
-        best_tiles: torch.Tensor,
-        n_steps: torch.Tensor,
         sampling_mode: str | None = "softmax",
         sampled_actions: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -80,10 +77,6 @@ class Policy(nn.Module):
         Args:
             tiles: The game state.
                 Long tensor of shape [batch_size, N_SIDES, board_height, board_width].
-            best_tiles: The game best state.
-                Long tensor of shape [batch_size, N_SIDES, board_height, board_width].
-            n_steps: Number of steps of each game.
-                Long tensor of shape [batch_size,].
             sampling_mode: The sampling mode of the actions.
                 One of ["sample", "greedy"].
             sampled_actions: The already sampled actions, if any.
@@ -105,7 +98,7 @@ class Policy(nn.Module):
         ), "Either sampling_mode or sampled_actions must be given."
         batch_size = tiles.shape[0]
 
-        tiles = self.backbone(tiles, best_tiles, n_steps)
+        tiles = self.backbone(tiles)
         actions, logprobs, entropies = [], [], []
 
         # Node selections.

--- a/src/policy_gradient/loss.py
+++ b/src/policy_gradient/loss.py
@@ -156,10 +156,10 @@ class PPOLoss(nn.Module):
         # entropies[:, 2] *= 0.10
         # entropies[:, 3] *= 0.10
         entropies = entropies.sum(dim=1)
-        metrics["loss/entropy"] = -entropies.mean()
-        metrics["loss/weighted-entropy"] = self.entropy_weight * metrics["loss/entropy"]
-        # metrics["loss/entropy"] = torch.relu(3.0 - entropies).mean()
-        # metrics["loss/weighted-entropy"] = metrics["loss/entropy"]
+        # metrics["loss/entropy"] = -entropies.mean()
+        # metrics["loss/weighted-entropy"] = self.entropy_weight * metrics["loss/entropy"]
+        metrics["loss/entropy"] = torch.relu(3.4 - entropies).mean()
+        metrics["loss/weighted-entropy"] = metrics["loss/entropy"]
 
         metrics["loss/total"] = (
             metrics["loss/weighted-policy"] + metrics["loss/weighted-entropy"]

--- a/src/policy_gradient/loss.py
+++ b/src/policy_gradient/loss.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 from tensordict import TensorDictBase
 from torchrl.objectives.value.functional import vec_generalized_advantage_estimate
 
-from ..model import Policy, Critic
+from ..model import Critic, Policy
 
 
 class PPOLoss(nn.Module):
@@ -75,7 +75,9 @@ class PPOLoss(nn.Module):
         traces["advantages"] = advantages.squeeze(-1)
         traces["value-targets"] = value_targets.squeeze(-1)
 
-    def forward(self, batch: TensorDictBase, policy: Policy, critic: Critic) -> dict[str, torch.Tensor]:
+    def forward(
+        self, batch: TensorDictBase, policy: Policy, critic: Critic
+    ) -> dict[str, torch.Tensor]:
         """Computes the PPO loss for both actor and critic models.
 
         ---
@@ -109,18 +111,8 @@ class PPOLoss(nn.Module):
         """
         metrics = dict()
 
-        _, logprobs, entropies = policy(
-            batch["states"],
-            batch["best-boards"],
-            batch["conditionals"],
-            None,
-            batch["actions"],
-        )
-        values = critic(
-            batch["states"],
-            batch["best-boards"],
-            batch["conditionals"],
-        )
+        _, logprobs, entropies = policy(batch["states"], None, batch["actions"])
+        values = critic(batch["states"])
 
         # Compute the joint log probability of the actions.
         logprobs = logprobs.sum(dim=1)


### PR DESCRIPTION
I like this framework better. The idea is to have the model to keep playing until the puzzle is solved. To be able to do so, we feed the model with intermediate rewards, based on the difference between the state of the puzzle before and after each action. I thought it was harder than having the model playing a fixed number of steps and forcing the episode to end (I thought the model would not be greedy and stay locked in a local maxima but it seems to still be happening).

This way of doing things simplify the way of looking at the states. I do not have to give the current timestep of the env, and do not have to give any information about the best reached state. This is simpler.